### PR TITLE
Fix mock pagination

### DIFF
--- a/app/Repositories/MockGiphyRepository.php
+++ b/app/Repositories/MockGiphyRepository.php
@@ -2,13 +2,14 @@
 namespace App\Repositories;
 
 use App\Interfaces\GiphyInterface;
+use App\Http\Controllers\GifsController;
 
 class MockGiphyRepository implements GiphyInterface
 {
 
     public function trending(int $limit, int $offset)
     {
-        $file = base_path() . '/resources/mocks/trending/' . $offset . '.json';
+        $file = base_path() . '/resources/mocks/trending/' . ($offset / GifsController::LIMIT) . '.json';
 
         if (file_exists($file)) {
             return json_decode(file_get_contents($file));


### PR DESCRIPTION
Inversion du calcul fait dans le controller pour retrouver la page.

Il faudrait peut être mieux étiqueter toutes les images de 1 à n et (ex: 23.gif) et taper dedans en se basant sur la limite et l'offset