### PR TITLE
Remove vue app loading from login view

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -7,4 +7,6 @@
 			:authenticated-user="{{ Auth::guest() ? '{}' : json_encode(Auth::user()) }}"
 		></application>
 	</div>
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}"></script>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -68,8 +68,5 @@
 
         @yield('content')
     </div>
-
-    <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Avoid an error message saying that #app tag was not found when entering on login page